### PR TITLE
fix: move min purchase amount state variable to DcaManager

### DIFF
--- a/script/DeployDexSwaps.s.sol
+++ b/script/DeployDexSwaps.s.sol
@@ -101,7 +101,7 @@ contract DeployDexSwaps is DeployBase {
         vm.startBroadcast();
 
         OperationsAdmin operationsAdmin = new OperationsAdmin();
-        DcaManager dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        DcaManager dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         address feeCollector = getFeeCollector(environment);
         
         address docHandlerDexAddress;

--- a/script/DeployMocAndUniswap.s.sol
+++ b/script/DeployMocAndUniswap.s.sol
@@ -72,7 +72,7 @@ contract DeployMocAndUniswap is DeployBase {
         vm.startBroadcast();
         // Deploy admin operations and DCA manager
         adOpsMoc = new OperationsAdmin();
-        dcaManMoc = new DcaManager(address(adOpsMoc), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        dcaManMoc = new DcaManager(address(adOpsMoc), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         
         // Get fee collector address
         address feeCollector = getFeeCollector(environment);
@@ -142,7 +142,7 @@ contract DeployMocAndUniswap is DeployBase {
         vm.startBroadcast();
         // Deploy admin operations and DCA manager
         adOpsUni = new OperationsAdmin();
-        dcaManUni = new DcaManager(address(adOpsUni), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        dcaManUni = new DcaManager(address(adOpsUni), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         
         // Get fee collector address
         address feeCollector = getFeeCollector(environment);

--- a/script/DeployMocSwaps.s.sol
+++ b/script/DeployMocSwaps.s.sol
@@ -113,7 +113,7 @@ contract DeployMocSwaps is DeployBase {
         vm.startBroadcast();
 
         OperationsAdmin operationsAdmin = new OperationsAdmin();
-        DcaManager dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        DcaManager dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         address feeCollector = getFeeCollector(environment);
         address docHandlerMocAddress;
 

--- a/src/DcaManager.sol
+++ b/src/DcaManager.sol
@@ -110,7 +110,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
     {
         DcaDetails storage dcaSchedule = s_dcaSchedules[msg.sender][token][scheduleIndex];
         _validateScheduleId(scheduleId, dcaSchedule.scheduleId);
-        _validatePurchaseAmount(token, purchaseAmount, dcaSchedule.tokenBalance, dcaSchedule.lendingProtocolIndex);
+        _validatePurchaseAmount(token, purchaseAmount, dcaSchedule.tokenBalance);
         dcaSchedule.purchaseAmount = purchaseAmount;
         emit DcaManager__PurchaseAmountSet(msg.sender, scheduleId, purchaseAmount);
     }
@@ -151,7 +151,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
     ) external override {
         _validatePurchasePeriod(purchasePeriod);
         _validateDeposit(depositAmount);
-        _validatePurchaseAmount(token, purchaseAmount, depositAmount, lendingProtocolIndex);
+        _validatePurchaseAmount(token, purchaseAmount, depositAmount);
         _handler(token, lendingProtocolIndex).depositToken(msg.sender, depositAmount);
 
         DcaDetails[] storage schedules = s_dcaSchedules[msg.sender][token];
@@ -209,7 +209,7 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
             _handler(token, dcaSchedule.lendingProtocolIndex).depositToken(msg.sender, depositAmount);
         }
         if (purchaseAmount > 0) {
-            _validatePurchaseAmount(token, purchaseAmount, dcaSchedule.tokenBalance, dcaSchedule.lendingProtocolIndex);
+            _validatePurchaseAmount(token, purchaseAmount, dcaSchedule.tokenBalance);
             dcaSchedule.purchaseAmount = purchaseAmount;
         }
 
@@ -455,13 +455,11 @@ contract DcaManager is IDcaManager, Ownable, ReentrancyGuard {
      * @param token: the token spent on DCA
      * @param purchaseAmount: the purchase amount to validate
      * @param tokenBalance: the current balance of the token in that DCA schedule
-     * @param lendingProtocolIndex: the index of the lending protocol
      */
     function _validatePurchaseAmount(
         address token,
         uint256 purchaseAmount,
-        uint256 tokenBalance,
-        uint256 lendingProtocolIndex
+        uint256 tokenBalance
     ) private view {
         uint256 minPurchaseAmount = s_tokenMinPurchaseAmounts[token];
         if (minPurchaseAmount == 0) {

--- a/src/SovrynDocHandlerMoc.sol
+++ b/src/SovrynDocHandlerMoc.sol
@@ -32,7 +32,6 @@ contract SovrynDocHandlerMoc is SovrynErc20Handler, PurchaseMoc {
             dcaManagerAddress,
             docTokenAddress,
             iSusdTokenAddress,
-            minPurchaseAmount,
             feeCollector,
             feeSettings,
             exchangeRateDecimals

--- a/src/SovrynErc20Handler.sol
+++ b/src/SovrynErc20Handler.sol
@@ -39,7 +39,7 @@ abstract contract SovrynErc20Handler is TokenHandler, TokenLending, ISovrynErc20
         FeeSettings memory feeSettings,
         uint256 exchangeRateDecimals
     )
-        TokenHandler(dcaManagerAddress, stableTokenAddress, minPurchaseAmount, feeCollector, feeSettings)
+        TokenHandler(dcaManagerAddress, stableTokenAddress, feeCollector, feeSettings)
         TokenLending(exchangeRateDecimals)
     {
         i_iSusdToken = IiSusdToken(iSusdTokenAddress);

--- a/src/SovrynErc20Handler.sol
+++ b/src/SovrynErc20Handler.sol
@@ -26,7 +26,6 @@ abstract contract SovrynErc20Handler is TokenHandler, TokenLending, ISovrynErc20
      * @param dcaManagerAddress the address of the DCA Manager contract
      * @param stableTokenAddress the address of the Dollar On Chain token on the blockchain of deployment
      * @param iSusdTokenAddress the address of Sovryn' iSusd token contract
-     * @param minPurchaseAmount  the minimum amount of stablecoin for periodic purchases
      * @param feeCollector the address of to which fees will sent on every purchase
      * @param feeSettings struct with the settings for fee calculations
      */
@@ -34,7 +33,6 @@ abstract contract SovrynErc20Handler is TokenHandler, TokenLending, ISovrynErc20
         address dcaManagerAddress,
         address stableTokenAddress,
         address iSusdTokenAddress,
-        uint256 minPurchaseAmount,
         address feeCollector,
         FeeSettings memory feeSettings,
         uint256 exchangeRateDecimals

--- a/src/SovrynErc20HandlerDex.sol
+++ b/src/SovrynErc20HandlerDex.sol
@@ -36,7 +36,6 @@ contract SovrynErc20HandlerDex is SovrynErc20Handler, PurchaseUniswap {
             dcaManagerAddress,
             stableTokenAddress,
             iSusdTokenAddress,
-            minPurchaseAmount,
             feeCollector,
             feeSettings,
             exchangeRateDecimals

--- a/src/TokenHandler.sol
+++ b/src/TokenHandler.sol
@@ -16,25 +16,21 @@ import {DcaManagerAccessControl} from "./DcaManagerAccessControl.sol";
 abstract contract TokenHandler is ITokenHandler, ERC165, Ownable, FeeHandler, DcaManagerAccessControl {
     using SafeERC20 for IERC20;
 
-    uint256 internal s_minPurchaseAmount; // The minimum amount of this token for periodic purchases
     IERC20 public immutable i_stableToken; // The stablecoin token to be deposited
 
     /**
      * @param dcaManagerAddress: the address of the DCA manager
      * @param tokenAddress: the address of the token to be deposited
-     * @param minPurchaseAmount: the minimum amount of the token to be deposited
      * @param feeCollector: the address of the fee collector
      * @param feeSettings: the fee settings
      */
     constructor(
         address dcaManagerAddress,
         address tokenAddress,
-        uint256 minPurchaseAmount,
         address feeCollector,
         FeeSettings memory feeSettings
     ) FeeHandler(feeCollector, feeSettings) DcaManagerAccessControl(dcaManagerAddress) {
         i_stableToken = IERC20(tokenAddress);
-        s_minPurchaseAmount = minPurchaseAmount;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -71,26 +67,5 @@ abstract contract TokenHandler is ITokenHandler, ERC165, Ownable, FeeHandler, Dc
      */
     function supportsInterface(bytes4 interfaceID) public view virtual override returns (bool) {
         return interfaceID == type(ITokenHandler).interfaceId || super.supportsInterface(interfaceID);
-    }
-
-    /**
-     * @notice modify the minimum purchase amount
-     * @param minPurchaseAmount: the new minimum purchase amount
-     */
-    function modifyMinPurchaseAmount(uint256 minPurchaseAmount) external override onlyOwner {
-        s_minPurchaseAmount = minPurchaseAmount;
-        emit TokenHandler__MinPurchaseAmountModified(minPurchaseAmount);
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                                GETTERS
-    //////////////////////////////////////////////////////////////*/
-
-    /**
-     * @notice get the minimum purchase amount
-     * @return the minimum purchase amount
-     */
-    function getMinPurchaseAmount() external view returns (uint256) {
-        return s_minPurchaseAmount;
     }
 }

--- a/src/TropykusDocHandlerMoc.sol
+++ b/src/TropykusDocHandlerMoc.sol
@@ -32,7 +32,6 @@ contract TropykusDocHandlerMoc is TropykusErc20Handler, PurchaseMoc {
             dcaManagerAddress,
             docTokenAddress,
             kDocTokenAddress,
-            minPurchaseAmount,
             feeCollector,
             feeSettings,
             exchangeRateDecimals

--- a/src/TropykusErc20Handler.sol
+++ b/src/TropykusErc20Handler.sol
@@ -39,7 +39,7 @@ abstract contract TropykusErc20Handler is TokenHandler, TokenLending, ITropykusE
         FeeSettings memory feeSettings,
         uint256 exchangeRateDecimals
     )
-        TokenHandler(dcaManagerAddress, stableTokenAddress, minPurchaseAmount, feeCollector, feeSettings)
+        TokenHandler(dcaManagerAddress, stableTokenAddress, feeCollector, feeSettings)
         TokenLending(exchangeRateDecimals)
     {
         i_kToken = IkToken(kTokenAddress);

--- a/src/TropykusErc20Handler.sol
+++ b/src/TropykusErc20Handler.sol
@@ -26,7 +26,6 @@ abstract contract TropykusErc20Handler is TokenHandler, TokenLending, ITropykusE
      * @param dcaManagerAddress the address of the DCA Manager contract
      * @param stableTokenAddress the address of the ERC20 stablecoin token on the blockchain of deployment
      * @param kTokenAddress the address of Tropykus'  kToken token contract
-     * @param minPurchaseAmount  the minimum amount of stablecoin for periodic purchases
      * @param feeCollector the address of to which fees will sent on every purchase
      * @param feeSettings struct with the settings for fee calculations
      */
@@ -34,7 +33,6 @@ abstract contract TropykusErc20Handler is TokenHandler, TokenLending, ITropykusE
         address dcaManagerAddress,
         address stableTokenAddress,
         address kTokenAddress,
-        uint256 minPurchaseAmount,
         address feeCollector,
         FeeSettings memory feeSettings,
         uint256 exchangeRateDecimals

--- a/src/TropykusErc20HandlerDex.sol
+++ b/src/TropykusErc20HandlerDex.sol
@@ -36,7 +36,6 @@ contract TropykusErc20HandlerDex is TropykusErc20Handler, PurchaseUniswap {
             dcaManagerAddress,
             docTokenAddress,
             kTokenAddress,
-            minPurchaseAmount,
             feeCollector,
             feeSettings,
             exchangeRateDecimals

--- a/src/interfaces/IDcaManager.sol
+++ b/src/interfaces/IDcaManager.sol
@@ -50,6 +50,8 @@ interface IDcaManager {
     event DcaManager__OperationsAdminUpdated(address indexed newOperationsAdmin);
     event DcaManager__MinPurchasePeriodModified(uint256 indexed newMinPurchasePeriod);
     event DcaManager__LastPurchaseTimestampUpdated(address indexed token, bytes32 indexed scheduleId, uint256 indexed lastPurchaseTimestamp);
+    event DcaManager__DefaultMinPurchaseAmountModified(uint256 indexed newDefaultMinPurchaseAmount);
+    event DcaManager__TokenMinPurchaseAmountSet(address indexed token, uint256 indexed minPurchaseAmount);
 
     //////////////////////
     // Errors ////////////
@@ -58,7 +60,7 @@ interface IDcaManager {
     error DcaManager__DepositAmountMustBeGreaterThanZero();
     error DcaManager__WithdrawalAmountMustBeGreaterThanZero();
     error DcaManager__WithdrawalAmountExceedsBalance(address token, uint256 amount, uint256 balance);
-    error DcaManager__PurchaseAmountMustBeGreaterThanMinimum(address token);
+    error DcaManager__PurchaseAmountMustBeGreaterThanMinimum(address token, uint256 minPurchaseAmount);
     error DcaManager__PurchasePeriodMustBeGreaterThanMinimum();
     error DcaManager__PurchaseAmountMustBeLowerThanHalfOfBalance();
     error DcaManager__CannotBuyIfPurchasePeriodHasNotElapsed(uint256 timeRemaining);
@@ -233,6 +235,16 @@ interface IDcaManager {
      */
     function modifyMaxSchedulesPerToken(uint256 maxSchedulesPerToken) external;
 
+    /**
+     * @dev modifies the default minimum purchase amount for all tokens
+     */
+    function modifyDefaultMinPurchaseAmount(uint256 defaultMinPurchaseAmount) external;
+
+    /**
+     * @dev sets a custom minimum purchase amount for a specific token
+     */
+    function setTokenMinPurchaseAmount(address token, uint256 minPurchaseAmount) external;
+
     //////////////////////
     // Getter functions //
     //////////////////////
@@ -355,4 +367,14 @@ interface IDcaManager {
      * @dev returns the maximum number of schedules per token
      */
     function getMaxSchedulesPerToken() external view returns (uint256);
+
+    /**
+     * @dev returns the default minimum purchase amount for all tokens
+     */
+    function getDefaultMinPurchaseAmount() external view returns (uint256);
+
+    /**
+     * @dev returns the minimum purchase amount for a specific token (0 if not set)
+     */
+    function getTokenMinPurchaseAmount(address token) external view returns (uint256 minPurchaseAmount, bool customMinAmountSet);
 }

--- a/src/interfaces/ITokenHandler.sol
+++ b/src/interfaces/ITokenHandler.sol
@@ -12,7 +12,6 @@ interface ITokenHandler {
     //////////////////////
     event TokenHandler__TokenDeposited(address indexed token, address indexed user, uint256 indexed amount);
     event TokenHandler__TokenWithdrawn(address indexed token, address indexed user, uint256 indexed amount);
-    event TokenHandler__MinPurchaseAmountModified(uint256 indexed newMinPurchaseAmount);
 
     ///////////////////////////////
     // External functions /////////
@@ -31,15 +30,4 @@ interface ITokenHandler {
      * @param user The user making the withdrawal.
      */
     function withdrawToken(address user, uint256 amount) external;
-
-    /**
-     * @dev modifies the minimum amount of the token that can be spent in each purchase
-     */
-    function modifyMinPurchaseAmount(uint256 minPurchaseAmount) external;
-
-    /**
-     * @dev Returns the minimum amount of the token that can be spent in each purchase.
-     * @return The minimum purchase amount in token units.
-     */
-    function getMinPurchaseAmount() external returns (uint256);
 }

--- a/test/ai-generated/fuzz/Handler.t.sol
+++ b/test/ai-generated/fuzz/Handler.t.sol
@@ -566,7 +566,7 @@ contract Handler is Test {
     }
     
     /**
-     * @notice Test modifying minimum purchase amount on token handlers (owner-only)
+     * @notice Test modifying minimum purchase amount on DCA manager (owner-only)
      */
     function modifyMinPurchaseAmount(
         uint256 newMinPurchaseAmount,
@@ -576,8 +576,15 @@ contract Handler is Test {
         lendingProtocolIndex = bound(lendingProtocolIndex, 1, 2);
         
         vm.startPrank(OWNER);
-        try tokenHandler.modifyMinPurchaseAmount(newMinPurchaseAmount) {
-            // Success - this tests the non-lending handler
+        try dcaManager.modifyDefaultMinPurchaseAmount(newMinPurchaseAmount) {
+            // Success - this tests the default minimum purchase amount
+        } catch {
+            // Ignore failures
+        }
+        
+        // Test setting custom amount for specific token
+        try dcaManager.setTokenMinPurchaseAmount(address(stablecoin), newMinPurchaseAmount) {
+            // Success - this tests setting custom amount per token
         } catch {
             // Ignore failures
         }

--- a/test/ai-generated/fuzz/Invariants.t.sol
+++ b/test/ai-generated/fuzz/Invariants.t.sol
@@ -351,7 +351,6 @@ contract TropykusHandlerWrapper is TropykusErc20Handler {
         dcaManagerAddress,
         stableTokenAddress,
         kTokenAddress,
-        minPurchaseAmount,
         feeCollector,
         feeSettings,
         EXCHANGE_RATE_DECIMALS
@@ -487,7 +486,6 @@ contract SovrynHandlerWrapper is SovrynErc20Handler {
         dcaManagerAddress,
         stableTokenAddress,
         iSusdTokenAddress,
-        minPurchaseAmount,
         feeCollector,
         feeSettings,
         EXCHANGE_RATE_DECIMALS

--- a/test/ai-generated/fuzz/Invariants.t.sol
+++ b/test/ai-generated/fuzz/Invariants.t.sol
@@ -86,7 +86,7 @@ contract InvariantTest is StdInvariant, Test {
         operationsAdmin = new OperationsAdmin();
         
         vm.prank(OWNER);
-        dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         
         stablecoin = new MockStablecoin(address(this));
         

--- a/test/ai-generated/unit/DcaManagerEdgeCasesTest.t.sol
+++ b/test/ai-generated/unit/DcaManagerEdgeCasesTest.t.sol
@@ -56,7 +56,7 @@ contract DcaManagerEdgeCasesTest is Test {
         operationsAdmin = new OperationsAdmin();
         
         vm.prank(OWNER);
-        dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         
         stablecoin = new MockStablecoin(address(this));
         kToken = new MockKdocToken(address(stablecoin));

--- a/test/ai-generated/unit/GettersTest.t.sol
+++ b/test/ai-generated/unit/GettersTest.t.sol
@@ -240,9 +240,25 @@ contract GettersTest is DcaDappTest {
                         TOKEN HANDLER GETTERS TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_tokenHandler_getMinPurchaseAmount() public {
-        uint256 minAmount = ITokenHandler(address(docHandler)).getMinPurchaseAmount();
-        assertGt(minAmount, 0);
+    function test_dcaManager_getMinPurchaseAmount() public {
+        uint256 defaultMinAmount = dcaManager.getDefaultMinPurchaseAmount();
+        assertGt(defaultMinAmount, 0);
+        
+        (uint256 effectiveMinAmount, bool isCustom) = dcaManager.getTokenMinPurchaseAmount(address(stablecoin));
+        assertEq(effectiveMinAmount, defaultMinAmount);
+        assertFalse(isCustom);
+        
+        // Test setting a custom amount for a token
+        vm.prank(OWNER);
+        dcaManager.setTokenMinPurchaseAmount(address(stablecoin), 50 ether);
+        
+        (uint256 customAmount, bool isCustomSet) = dcaManager.getTokenMinPurchaseAmount(address(stablecoin));
+        assertEq(customAmount, 50 ether);
+        assertTrue(isCustomSet);
+        
+        (uint256 newEffectiveAmount, bool newIsCustom) = dcaManager.getTokenMinPurchaseAmount(address(stablecoin));
+        assertEq(newEffectiveAmount, 50 ether);
+        assertTrue(newIsCustom);
     }
 
     function test_tokenHandler_supportsInterface() public {

--- a/test/ai-generated/unit/RoleSecurityTest.t.sol
+++ b/test/ai-generated/unit/RoleSecurityTest.t.sol
@@ -57,7 +57,7 @@ contract RoleSecurityTest is Test {
         operationsAdmin = new OperationsAdmin();
         
         vm.prank(OWNER);
-        dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN);
+        dcaManager = new DcaManager(address(operationsAdmin), MIN_PURCHASE_PERIOD, MAX_SCHEDULES_PER_TOKEN, MIN_PURCHASE_AMOUNT);
         
         stablecoin = new MockStablecoin(address(this));
         kToken = new MockKdocToken(address(stablecoin));

--- a/test/ai-generated/unit/SovrynErc20HandlerTest.t.sol
+++ b/test/ai-generated/unit/SovrynErc20HandlerTest.t.sol
@@ -339,7 +339,6 @@ contract SovrynTestHandler is SovrynErc20Handler {
         dcaManagerAddress,
         stableTokenAddress, 
         iSusdTokenAddress,
-        minPurchaseAmount,
         feeCollector,
         feeSettings,
         EXCHANGE_RATE_DECIMALS

--- a/test/ai-generated/unit/TropykusErc20HandlerTest.t.sol
+++ b/test/ai-generated/unit/TropykusErc20HandlerTest.t.sol
@@ -219,7 +219,6 @@ contract TropykusTestHandler is TropykusErc20Handler {
         dcaManagerAddress,
         stableTokenAddress, 
         kTokenAddress,
-        minPurchaseAmount,
         feeCollector,
         feeSettings,
         EXCHANGE_RATE_DECIMALS

--- a/test/unit/StablecoinHandlerTest.sol
+++ b/test/unit/StablecoinHandlerTest.sol
@@ -27,15 +27,6 @@ contract StablecoinHandlerTest is DcaDappTest {
         assertEq(IERC165(address(docHandler)).supportsInterface(type(ITokenHandler).interfaceId), true);
     }
 
-    function testStablecoinHandlerModifyMinPurchaseAmount() external {
-        vm.prank(OWNER);
-        vm.expectEmit(true, true, true, true);
-        emit TokenHandler__MinPurchaseAmountModified(1000);
-        docHandler.modifyMinPurchaseAmount(1000);
-        uint256 newPurchaseAmount = docHandler.getMinPurchaseAmount();
-        assertEq(newPurchaseAmount, 1000);
-    }
-
     function testStablecoinHandlerSetFeeRateParams() external {
         vm.prank(OWNER);
         IFeeHandler(address(docHandler)).setFeeRateParams(5, 5, 5, 5);


### PR DESCRIPTION
With this PR we have moved the min purchase amount logic to DcaManager, where it makes much more sense and is more gas efficient.